### PR TITLE
♻️ refactor(workflow): Remove redundant npm cache configuration

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -25,7 +25,6 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: '20'
-          cache: 'npm'
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
- Simplified the GitHub Actions workflow by removing the unused `cache: 'npm'` setting.